### PR TITLE
InvalidPointerId on Android 6

### DIFF
--- a/src/js/jquery.bxslider.js
+++ b/src/js/jquery.bxslider.js
@@ -1102,6 +1102,7 @@
         slider.touch.originalPos = el.position();
         var orig = e.originalEvent,
         touchPoints = (typeof orig.changedTouches !== 'undefined') ? orig.changedTouches : [orig];
+	var chromePointerEvents = typeof PointerEvent === 'function'; if (chromePointerEvents) { if (orig.pointerId === undefined) { return; } }
         // record the starting touch x, y coordinates
         slider.touch.start.x = touchPoints[0].pageX;
         slider.touch.start.y = touchPoints[0].pageY;


### PR DESCRIPTION
I have referred following URL & found the code which is not merged yet

https://stackoverflow.com/questions/41723250/bxslider-error-invalidpointerid-on-android-6-0-1
https://github.com/stevenwanderski/bxslider-4/issues/1086#issuecomment-276687028